### PR TITLE
fix: type check and fix tests

### DIFF
--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -22,7 +22,7 @@ const iteratorMock = jest.fn().mockReturnValue([].values());
 
 // @ts-expect-error - This is sufficient for a mock
 const qi: QueryIterator<StringToAnyObjectMap> = QueryIterator;
-
+// @ts-expect-error - Mock the iterator
 qi[Symbol.iterator] = iteratorMock;
 
 querySpy.mockReturnValue(qi);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,5 +31,5 @@
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Check types in the `test` directory and add directives to fix the mocks. Now, tests run fine again and coverage is back at where it has been previously.